### PR TITLE
Atom 1.0 compatibility

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -20,8 +20,8 @@ module.exports = {
         var editor      = atom.workspace.getActivePaneItem(),
             fileName    = editor.getTitle(),
             range       = editor.getSelectedBufferRange(),
-            selection   = editor.getSelection(),
-            cursor      = editor.getCursor(),
+            selection   = editor.getLastSelection(),
+            cursor      = editor.getLastCursor(),
             text        = selection.getText(),
             ext         = getExtension(fileName);
 
@@ -62,7 +62,7 @@ function toggleHtmlSingleLineOrEmptySelection(ext, editor) {
     editor.selectToBeginningOfLine();
 
     range = editor.getSelectedBufferRange();
-    selection = editor.getSelection();
+    selection = editor.getLastSelection();
     text = selection.getText();
 
     editor.setTextInBufferRange(range, toggleComments(text, ext, 'singleline'));

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     toggle: function() {
-        var editor      = atom.workspace.activePaneItem,
+        var editor      = atom.workspace.getActivePaneItem(),
             fileName    = editor.getTitle(),
             range       = editor.getSelectedBufferRange(),
             selection   = editor.getSelection(),

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -58,7 +58,7 @@ function toggleHtmlSingleLineOrEmptySelection(ext, editor) {
     var range, text, selection;
 
     // Make selection
-    editor.moveCursorToEndOfLine();
+    editor.moveToEndOfLine();
     editor.selectToBeginningOfLine();
 
     range = editor.getSelectedBufferRange();
@@ -66,8 +66,8 @@ function toggleHtmlSingleLineOrEmptySelection(ext, editor) {
     text = selection.getText();
 
     editor.setTextInBufferRange(range, toggleComments(text, ext, 'singleline'));
-    editor.moveCursorDown();
-    editor.moveCursorToBeginningOfLine();
+    editor.moveDown();
+    editor.moveToBeginningOfLine();
 }
 
 
@@ -96,10 +96,10 @@ function toggleCommentsForSingleLine(text, ext, editor) {
         modifiedText = text.substr(prefix.length, text.length) + '\n';
         editor.insertText(modifiedText);
     } else {
-        editor.moveCursorToBeginningOfLine();
+        editor.moveToBeginningOfLine();
         modifiedText = prefix;
         editor.insertText(modifiedText);
-        editor.moveCursorDown();
+        editor.moveDown();
     }
 
     return modifiedText;

--- a/menus/block-comment.cson
+++ b/menus/block-comment.cson
@@ -1,6 +1,6 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer': [{
+  'atom-text-editor': [{
     'label': 'Toggle comment', 'command': 'comment:toggle'
   }]
 

--- a/menus/block-comment.cson
+++ b/menus/block-comment.cson
@@ -1,7 +1,8 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
-  '.overlayer':
-      'Toggle comment': 'comment:toggle'
+  '.overlayer': [{
+    'label': 'Toggle comment', 'command': 'comment:toggle'
+  }]
 
 'menu': [
   {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "main": "./lib/comment",
   "version": "0.2.8",
   "description": "Insert block comments or single line comments on selected text with keyboard shortcut",
-  "activationEvents": [
-    "comment:toggle",
-    "comment:toggleSingleLine"
-  ],
+  "activationCommands": {
+    "atom-text-editor": [
+      "comment:toggle",
+      "comment:toggleSingleLine"
+    ]
+  },
   "scripts": {
     "test": "./node_modules/jasmine-node/bin/jasmine-node --verbose spec/"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "comment",
   "main": "./lib/comment",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Insert block comments or single line comments on selected text with keyboard shortcut",
   "activationEvents": [
     "comment:toggle",

--- a/styles/comment.less
+++ b/styles/comment.less
@@ -1,9 +1,9 @@
 // The ui-variables file is provided by base themes provided by Atom.
 //
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
+// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
 
 .comment {
-    
+
 }


### PR DESCRIPTION
Developed/tested on Atom 1.0.7 (OS X).
Fixes #14.
Fixes #15.
Fixes #16.
Fixes #17.

After this PR is merged we should be able to install the package into the latest version of Atom again :-)